### PR TITLE
Add validation for public key size in verify_digits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Martin Jonas <martinjonas@gmail.com>"]
 
 [dependencies]
-bitcoin-script-stack = { git = "https://github.com/FairgateLabs/rust-bitcoin-script-stack" }
+bitcoin-script-stack = { path = "../rust-bitcoin-script-stack", branch = "v2" }
 bitcoin-script = { git = "https://github.com/FairgateLabs/rust-bitcoin-script", branch = "bitvmx" }
 bitcoin = "=0.32.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Martin Jonas <martinjonas@gmail.com>"]
 
 [dependencies]
-bitcoin-script-stack = { path = "../rust-bitcoin-script-stack", branch = "v2" }
+bitcoin-script-stack = { git = "https://github.com/FairgateLabs/rust-bitcoin-script-stack", branch = "v2" }
 bitcoin-script = { git = "https://github.com/FairgateLabs/rust-bitcoin-script", branch = "bitvmx" }
 bitcoin = "=0.32.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Martin Jonas <martinjonas@gmail.com>"]
 
 [dependencies]
-bitcoin-script-stack = { git = "https://github.com/FairgateLabs/rust-bitcoin-script-stack", branch = "v2" }
+bitcoin-script-stack = { git = "https://github.com/FairgateLabs/rust-bitcoin-script-stack" }
 bitcoin-script = { git = "https://github.com/FairgateLabs/rust-bitcoin-script", branch = "bitvmx" }
 bitcoin = "=0.32.6"
 

--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -94,6 +94,34 @@ pub fn winternitz_checksig(
     stack.equals(checksum, true, reconstructed, true);
 }
 
+pub fn get_winternitz_checksig_script(
+    public_keys: &Vec<String>,
+    message_size: u32,
+    max: u8,
+    bits_per_digit: u8,
+    keep_message: bool,
+) -> bitcoin::ScriptBuf {
+    let mut stack = StackTracker::new();
+
+    // Define the public keys and hints in the stack (needed for the stack tracker to work)
+    for i in 0..public_keys.len() {
+        stack.define(1, format!("public_key_{}", i).as_str());
+        stack.define(1, format!("hint_{}", i).as_str());
+    }
+
+    winternitz_checksig(
+        &mut stack,
+        public_keys,
+        message_size,
+        max,
+        bits_per_digit,
+        keep_message,
+    );
+
+    // Return the script from the stack tracker, defined variables are not included in the script.
+    stack.get_script()
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -1,4 +1,3 @@
-use bitcoin::secp256k1::SecretKey;
 use bitcoin_script_stack::stack::{StackTracker, StackVariable};
 pub const DIGITS_PER_BIT: u8 = 4;
 pub const BASE: u8 = 1 << DIGITS_PER_BIT;
@@ -98,34 +97,6 @@ pub fn winternitz_checksig(
             stack.to_altstack();
         }
     }
-}
-
-pub fn get_winternitz_checksig_script(
-    public_keys: &Vec<String>,
-    message_size: u32,
-    max: u8,
-    bits_per_digit: u8,
-    keep_message: bool,
-) -> bitcoin::ScriptBuf {
-    let mut stack = StackTracker::new();
-
-    // Define the public keys and hints in the stack (needed for the stack tracker to work)
-    for i in 0..public_keys.len() {
-        stack.define(1, format!("public_key_{}", i).as_str());
-        stack.define(1, format!("hint_{}", i).as_str());
-    }
-
-    winternitz_checksig(
-        &mut stack,
-        public_keys,
-        message_size,
-        max,
-        bits_per_digit,
-        keep_message,
-    );
-
-    // Return the script from the stack tracker, defined variables are not included in the script.
-    stack.get_script()
 }
 
 #[cfg(test)]

--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -154,7 +154,7 @@ mod tests {
     }
 
     fn calculate_checksum(msg: &Vec<u8>, max_value_digit: u8) -> u32 {
-        let sum = msg.iter().sum::<u8>() as u32;
+        let sum: u32 = msg.iter().map(|x| *x as u32).sum();
         let max_value_all = max_value_digit as u32 * msg.len() as u32;
         assert!(sum <= max_value_all as u32);
         max_value_all as u32 - sum

--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -92,6 +92,12 @@ pub fn winternitz_checksig(
     let checksum_size = public_keys.len() as u32 - message_size;
     let reconstructed = reconstruct_checksum(stack, checksum_size, bits_per_digit);
     stack.equals(checksum, true, reconstructed, true);
+
+    if keep_message {
+        for _ in 0..message_size {
+            stack.to_altstack();
+        }
+    }
 }
 
 pub fn get_winternitz_checksig_script(
@@ -252,7 +258,51 @@ mod tests {
     }
 
     #[test]
-    fn test_winternitz() {
+    fn test_winternitz_keep_message() {
+        let mut stack = StackTracker::new();
+
+        let message_size = 2;
+        let max = MAX;
+        let base = BASE;
+        let bits_per_digit = 4;
+
+        let secrets = vec!["00", "11", "22", "33"]
+            .iter()
+            .map(|s| hash160(s))
+            .collect::<Vec<String>>();
+
+        let public_keys = secrets.iter().rev().map(|s| public_key(s, max)).collect();
+
+        let msg = vec![15, 15];
+
+        // witness generation
+        let checksum = calculate_checksum(&msg, max);
+        let checksum_digits = to_base_padded(checksum, base, max as u32 * msg.len() as u32);
+        let msg_and_chk: Vec<u8> = msg.iter().chain(checksum_digits.iter()).cloned().collect();
+
+        for i in 0..msg_and_chk.len() {
+            stack.hexstr(&sign_digit(&secrets[i], msg_and_chk[i] as u8));
+            stack.number(msg_and_chk[i] as u32);
+        }
+
+        // verification script
+
+        winternitz_checksig(
+            &mut stack,
+            &public_keys,
+            message_size,
+            max,
+            bits_per_digit,
+            true,
+        );
+
+        stack.op_true();
+
+        assert!(stack.run().success);
+    }
+
+    #[test]
+    fn test_winternitz_do_not_keep_message() {
         let mut stack = StackTracker::new();
 
         let message_size = 2;
@@ -289,8 +339,6 @@ mod tests {
             bits_per_digit,
             false,
         );
-
-        println!("Script size: {}", stack.get_script().len());
 
         stack.op_true();
 

--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -43,7 +43,7 @@ fn reconstruct_checksum(stack: &mut StackTracker, checksum_size: u32, bits: u8) 
 }
 
 fn verify_digits(stack: &mut StackTracker, public_keys: &Vec<String>, max: u8) {
-    const PUBLIC_KEY_SIZE: u32 = 20;
+    const OTS_SIZE: u32 = 20;
 
     for digit in 0..public_keys.len() {
         // This is a sanitization of the hint to ensure the hint do not exceed the max times to hash the secret key.
@@ -55,9 +55,9 @@ fn verify_digits(stack: &mut StackTracker, public_keys: &Vec<String>, max: u8) {
         stack.to_altstack();
         stack.to_altstack();
 
-        // Check if the public key is 20 bytes
+        // Check if the one-time signature is 20 bytes
         stack.op_size();
-        stack.number(PUBLIC_KEY_SIZE);
+        stack.number(OTS_SIZE);
         stack.op_equalverify();
 
         //creates all the hashes from the provided secret key on the stack

--- a/src/signatures/winternitz.rs
+++ b/src/signatures/winternitz.rs
@@ -1,5 +1,5 @@
+use bitcoin::secp256k1::SecretKey;
 use bitcoin_script_stack::stack::{StackTracker, StackVariable};
-
 pub const DIGITS_PER_BIT: u8 = 4;
 pub const BASE: u8 = 1 << DIGITS_PER_BIT;
 pub const MAX: u8 = BASE - 1;
@@ -44,15 +44,22 @@ fn reconstruct_checksum(stack: &mut StackTracker, checksum_size: u32, bits: u8) 
 }
 
 fn verify_digits(stack: &mut StackTracker, public_keys: &Vec<String>, max: u8) {
+    const PUBLIC_KEY_SIZE: u32 = 20;
+
     for digit in 0..public_keys.len() {
-        //sanitize hint
+        // This is a sanitization of the hint to ensure the hint do not exceed the max times to hash the secret key.
         stack.number(max as u32);
         stack.op_min();
 
-        //save two copies of the hint
+        // Save two copies of the hint
         stack.op_dup();
         stack.to_altstack();
         stack.to_altstack();
+
+        // Check if the public key is 20 bytes
+        stack.op_size();
+        stack.number(PUBLIC_KEY_SIZE);
+        stack.op_equalverify();
 
         //creates all the hashes from the provided secret key on the stack
         for _ in 0..max {
@@ -64,7 +71,6 @@ fn verify_digits(stack: &mut StackTracker, public_keys: &Vec<String>, max: u8) {
         stack.op_pick();
 
         stack.hexstr(&public_keys[digit]);
-
         stack.op_equalverify();
 
         for _ in 0..(max + 1) / 2 {
@@ -155,19 +161,26 @@ mod tests {
     fn test_verify_digits() {
         let mut stack = StackTracker::new();
 
-        let max = 3;
+        // Max hashes until public key
+        // priv_0 = secret
+        // priv_1 = H(secret)
+        // priv_2 = H(priv_1)
+        // public_key = H(priv_2)
+        let times_to_pubkey = 3;
+        let hint = 0; // This could be 0, 1, or 2.
 
-        let digit = 0;
-        let secret = "deadbeef";
-        let public_key = public_key(secret, max);
-        println!("Public key: {}", public_key);
-        let signed = sign_digit(secret, digit);
-        println!("Signed: {}", signed);
+        // Secret key should be 20 bytes otherwise the script will fail (in case hint 0 = priv_0 = secret)
+        let secret = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let public_key = public_key(secret, times_to_pubkey);
+        let signed = sign_digit(secret, hint);
 
         stack.hexstr(&signed);
-        stack.number(digit as u32);
+        stack.number(hint as u32);
 
-        verify_digits(&mut stack, &vec![public_key], max);
+        verify_digits(&mut stack, &vec![public_key], times_to_pubkey);
+
+        stack.op_true();
+        assert!(stack.run().success);
     }
 
     #[test]


### PR DESCRIPTION
## Changes 

- Add validation for public key size in verify_digits
- Add a new function to get the script after call winternitz_checksig

## This change is related to other PRs in different libraries, such as:

[Stack](https://github.com/FairgateLabs/rust-bitcoin-script-stack/pull/8)

[Key Manager](https://github.com/FairgateLabs/rust-bitvmx-key-manager/pull/58) 

[Protocol Builder](https://github.com/FairgateLabs/rust-bitvmx-protocol-builder/pull/59)